### PR TITLE
Added simple script to build on windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ examples of source code libraries that have been amalgamated:
 - **[JUCE][2]** http://github.com/vinniefalco/JUCEAmalgam
 - **[TagLib][3]** http://github.com/vinniefalco/TagLibAmalgam
 
+## How to build
+
+On linux simply running `make all` should be sufficient to build the program.
+
+On windows you should use the `build.bat` script which requires the MSVC command line toolchain to be enabled. You can read about how to enable it [here](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=vs-2019).
+
 ## Usage
 
 ```plain

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,4 @@
+@echo off
+
+cl *.cpp /EHsc /nologo /Fe:amalgamate /link ole32.lib
+del *.obj


### PR DESCRIPTION
Hi, 

I really like this tool and found it very useful for my project. I work on windows so I had to spend a bit of time getting it to compile properly as the make file was designed with linux in mind.

Initially, I wanted to add a cmake file but I could only get this to compile under MSVC, I can't figure out why it won't work with mingw, so I made a simple batch file instead. 

The change just adds the simple batch file for building on windows and a tiny section on `how-to-build` in the readme. 